### PR TITLE
feat(speaking): add LLM-powered question selection planner with heuristic fallback

### DIFF
--- a/backend/src/main/java/com/cramer/config/SpeakingSelectionPlannerConfig.java
+++ b/backend/src/main/java/com/cramer/config/SpeakingSelectionPlannerConfig.java
@@ -1,0 +1,54 @@
+package com.cramer.config;
+
+import com.cramer.service.SpeakingSelectionPlannerService;
+import com.cramer.service.implement.HeuristicSpeakingSelectionPlannerService;
+import com.cramer.service.implement.LlmSpeakingSelectionPlannerService;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Wires the {@link SpeakingSelectionPlannerService} bean based on configuration.
+ *
+ * <ul>
+ *   <li>{@code speaking.selection.provider=llm} → {@link LlmSpeakingSelectionPlannerService}
+ *       (with {@link HeuristicSpeakingSelectionPlannerService} as internal fallback)</li>
+ *   <li>Any other value or missing → {@link HeuristicSpeakingSelectionPlannerService}
+ *       via {@link ConditionalOnMissingBean}</li>
+ * </ul>
+ *
+ * @since 2026-04-05
+ */
+@Configuration
+public class SpeakingSelectionPlannerConfig {
+
+    @Bean
+    @ConditionalOnProperty(name = "speaking.selection.provider", havingValue = "llm")
+    public SpeakingSelectionPlannerService llmSpeakingSelectionPlanner(
+            OpenRouterConfig openRouterConfig,
+            SpeakingSelectionProperties selectionProperties,
+            SpeakingSelectionPromptBuilder promptBuilder,
+            HeuristicSpeakingSelectionPlannerService heuristicFallback) {
+        RestTemplate selectionRestTemplate = buildSelectionRestTemplate(selectionProperties);
+        return new LlmSpeakingSelectionPlannerService(
+                openRouterConfig, selectionProperties, promptBuilder,
+                heuristicFallback, selectionRestTemplate);
+    }
+
+    @Bean
+    @ConditionalOnMissingBean(SpeakingSelectionPlannerService.class)
+    public HeuristicSpeakingSelectionPlannerService heuristicSpeakingSelectionPlanner() {
+        return new HeuristicSpeakingSelectionPlannerService();
+    }
+
+    private RestTemplate buildSelectionRestTemplate(SpeakingSelectionProperties props) {
+        SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+        factory.setConnectTimeout(5000);
+        factory.setReadTimeout(props.getTimeoutMs());
+        return new RestTemplate(factory);
+    }
+}

--- a/backend/src/main/java/com/cramer/config/SpeakingSelectionProperties.java
+++ b/backend/src/main/java/com/cramer/config/SpeakingSelectionProperties.java
@@ -1,0 +1,111 @@
+package com.cramer.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configuration properties for Speaking question selection strategy.
+ *
+ * <p>Controls whether questions are selected by heuristic algorithm or by an
+ * LLM provider. When {@code provider} is set to {@code "llm"}, the system
+ * calls the configured model via OpenRouter to choose a coherent subset of
+ * questions from the authored bank. If the LLM call fails, times out, or
+ * returns invalid output, the system falls back to the heuristic planner.</p>
+ *
+ * @since 2026-04-05
+ */
+@Configuration
+@ConfigurationProperties(prefix = "speaking.selection")
+public class SpeakingSelectionProperties {
+
+    /**
+     * Selection provider: {@code "heuristic"} (default) or {@code "llm"}.
+     */
+    private String provider = "heuristic";
+
+    /**
+     * OpenRouter model ID for LLM selection (e.g. {@code "deepseek/deepseek-chat-v3-0324"}).
+     * Ignored when provider is {@code "heuristic"}.
+     */
+    private String model = "";
+
+    /**
+     * Read timeout in milliseconds for the LLM selection call.
+     * Selection returns a small JSON payload and should be fast.
+     * Default 12 000 ms (12 seconds).
+     */
+    private int timeoutMs = 12000;
+
+    /**
+     * Fallback strategy when LLM call fails. Currently only {@code "heuristic"} is supported.
+     */
+    private String fallback = "heuristic";
+
+    /**
+     * Sampling temperature for the LLM selection call.
+     */
+    private double temperature = 0.7;
+
+    /**
+     * Maximum tokens for the LLM selection response.
+     * The response is a small JSON with integer IDs and a short summary.
+     */
+    private int maxTokens = 512;
+
+    // --- Getters and Setters ---
+
+    public String getProvider() {
+        return provider;
+    }
+
+    public void setProvider(String provider) {
+        this.provider = provider;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public int getTimeoutMs() {
+        return timeoutMs;
+    }
+
+    public void setTimeoutMs(int timeoutMs) {
+        this.timeoutMs = timeoutMs;
+    }
+
+    public String getFallback() {
+        return fallback;
+    }
+
+    public void setFallback(String fallback) {
+        this.fallback = fallback;
+    }
+
+    public double getTemperature() {
+        return temperature;
+    }
+
+    public void setTemperature(double temperature) {
+        this.temperature = temperature;
+    }
+
+    public int getMaxTokens() {
+        return maxTokens;
+    }
+
+    public void setMaxTokens(int maxTokens) {
+        this.maxTokens = maxTokens;
+    }
+
+    /**
+     * Returns {@code true} if a model is configured for LLM selection.
+     */
+    public boolean hasModel() {
+        return model != null && !model.trim().isEmpty();
+    }
+}

--- a/backend/src/main/java/com/cramer/service/implement/HeuristicSpeakingSelectionPlannerService.java
+++ b/backend/src/main/java/com/cramer/service/implement/HeuristicSpeakingSelectionPlannerService.java
@@ -18,9 +18,16 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.springframework.stereotype.Service;
 
-@Service
+/**
+ * Heuristic (non-LLM) implementation of {@link SpeakingSelectionPlannerService}.
+ *
+ * <p>Uses topic-clustering and token-overlap scoring to select questions.
+ * Also serves as the fallback when the LLM planner fails.</p>
+ *
+ * <p>This class is <strong>not</strong> annotated with {@code @Service};
+ * bean registration is handled by {@code SpeakingSelectionPlannerConfig}.</p>
+ */
 public class HeuristicSpeakingSelectionPlannerService implements SpeakingSelectionPlannerService {
 
     private static final Pattern TOKEN_SPLIT = Pattern.compile("[^a-z0-9]+");

--- a/backend/src/main/java/com/cramer/service/implement/LlmSpeakingSelectionPlannerService.java
+++ b/backend/src/main/java/com/cramer/service/implement/LlmSpeakingSelectionPlannerService.java
@@ -1,0 +1,285 @@
+package com.cramer.service.implement;
+
+import com.cramer.config.OpenRouterConfig;
+import com.cramer.config.SpeakingSelectionProperties;
+import com.cramer.config.SpeakingSessionProperties;
+import com.cramer.service.SpeakingSelectionPlannerService;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.PromptPair;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.SelectionParseResult;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * LLM-powered implementation of {@link SpeakingSelectionPlannerService}.
+ *
+ * <p>Calls an OpenRouter-compatible LLM to select a coherent subset of
+ * questions from the authored bank. On any failure (timeout, invalid
+ * response, parse error), falls back to the heuristic planner.</p>
+ *
+ * <p>This class is <strong>not</strong> annotated with {@code @Service};
+ * it is wired via {@code SpeakingSelectionPlannerConfig}.</p>
+ *
+ * @since 2026-04-05
+ */
+public class LlmSpeakingSelectionPlannerService implements SpeakingSelectionPlannerService {
+
+    private static final Logger log = LoggerFactory.getLogger(LlmSpeakingSelectionPlannerService.class);
+    private static final String STRATEGY_LLM = "llm_selection_v1";
+
+    private final OpenRouterConfig openRouterConfig;
+    private final SpeakingSelectionProperties selectionProperties;
+    private final SpeakingSelectionPromptBuilder promptBuilder;
+    private final HeuristicSpeakingSelectionPlannerService heuristicFallback;
+    private final RestTemplate selectionRestTemplate;
+    private final SecureRandom random = new SecureRandom();
+
+    public LlmSpeakingSelectionPlannerService(
+            OpenRouterConfig openRouterConfig,
+            SpeakingSelectionProperties selectionProperties,
+            SpeakingSelectionPromptBuilder promptBuilder,
+            HeuristicSpeakingSelectionPlannerService heuristicFallback,
+            RestTemplate selectionRestTemplate) {
+        this.openRouterConfig = openRouterConfig;
+        this.selectionProperties = selectionProperties;
+        this.promptBuilder = promptBuilder;
+        this.heuristicFallback = heuristicFallback;
+        this.selectionRestTemplate = selectionRestTemplate;
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Public interface methods
+    // ──────────────────────────────────────────────────────────────
+
+    @Override
+    public SelectionResult selectPart1(List<PlannerCandidate> bank, SpeakingSessionProperties.PartPlan config) {
+        if (!isLlmAvailable("Part 1")) {
+            return heuristicFallback.selectPart1(bank, config);
+        }
+        int targetTurnCount = pickTargetTurnCount(config);
+        PromptPair prompt = promptBuilder.buildPart1Prompt(bank, targetTurnCount);
+        return callLlmWithFallback("Part 1", bank, targetTurnCount, prompt,
+                () -> heuristicFallback.selectPart1(bank, config));
+    }
+
+    @Override
+    public SelectionResult selectPart2(List<PlannerCandidate> bank, SpeakingSessionProperties.PartPlan config) {
+        // Part 2 always uses heuristic — picking 1 cue card from a bank of 1
+        return heuristicFallback.selectPart2(bank, config);
+    }
+
+    @Override
+    public SelectionResult selectIndependentPart3(List<PlannerCandidate> bank, SpeakingSessionProperties.PartPlan config) {
+        if (!isLlmAvailable("Part 3 independent")) {
+            return heuristicFallback.selectIndependentPart3(bank, config);
+        }
+        int targetTurnCount = pickTargetTurnCount(config);
+        PromptPair prompt = promptBuilder.buildIndependentPart3Prompt(bank, targetTurnCount);
+        return callLlmWithFallback("Part 3 independent", bank, targetTurnCount, prompt,
+                () -> heuristicFallback.selectIndependentPart3(bank, config));
+    }
+
+    @Override
+    public SelectionResult selectFollowUpPart3(
+            List<PlannerCandidate> bank,
+            JsonNode part2QuestionSnapshot,
+            String part2TranscriptText,
+            SpeakingSessionProperties.PartPlan config) {
+        if (!isLlmAvailable("Part 3 follow-up")) {
+            return heuristicFallback.selectFollowUpPart3(bank, part2QuestionSnapshot, part2TranscriptText, config);
+        }
+        int targetTurnCount = pickTargetTurnCount(config);
+        PromptPair prompt = promptBuilder.buildFollowUpPart3Prompt(
+                bank, targetTurnCount, part2QuestionSnapshot, part2TranscriptText);
+        return callLlmWithFallback("Part 3 follow-up", bank, targetTurnCount, prompt,
+                () -> heuristicFallback.selectFollowUpPart3(bank, part2QuestionSnapshot, part2TranscriptText, config));
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Guard: check LLM availability (model + API key)
+    // ──────────────────────────────────────────────────────────────
+
+    /**
+     * Returns {@code true} if LLM selection can be attempted (model and API key
+     * are both configured). Logs a warning and returns {@code false} otherwise.
+     */
+    private boolean isLlmAvailable(String partLabel) {
+        if (!selectionProperties.hasModel()) {
+            log.warn("LLM selection for {} skipped: no model configured, falling back to heuristic", partLabel);
+            return false;
+        }
+        if (!openRouterConfig.hasApiKey()) {
+            log.warn("LLM selection for {} skipped: OPENROUTER_API_KEY not configured, falling back to heuristic", partLabel);
+            return false;
+        }
+        return true;
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Core LLM call with fallback
+    // ──────────────────────────────────────────────────────────────
+
+    private SelectionResult callLlmWithFallback(
+            String partLabel,
+            List<PlannerCandidate> bank,
+            int targetTurnCount,
+            PromptPair prompt,
+            FallbackSupplier fallback) {
+
+        try {
+            long startTime = System.currentTimeMillis();
+            String llmContent = callOpenRouter(prompt);
+            long duration = System.currentTimeMillis() - startTime;
+
+            log.info("LLM selection for {} completed in {}ms", partLabel, duration);
+
+            SelectionParseResult parseResult = promptBuilder.parseAndValidate(llmContent, bank, targetTurnCount);
+            if (!parseResult.valid()) {
+                log.warn("LLM selection for {} returned invalid output: {}. Falling back to heuristic.",
+                        partLabel, parseResult.error());
+                return fallback.get();
+            }
+
+            // Resolve IDs back to PlannerCandidate objects, preserving LLM order
+            List<PlannerCandidate> selected = resolveSelectedCandidates(bank, parseResult.selectedIds());
+
+            if (!parseResult.reasoningSummary().isEmpty()) {
+                log.info("LLM selection reasoning for {}: {}", partLabel, parseResult.reasoningSummary());
+            }
+
+            return new SelectionResult(targetTurnCount, selected, STRATEGY_LLM);
+
+        } catch (Exception e) {
+            log.warn("LLM selection for {} failed with {}: {}. Falling back to heuristic.",
+                    partLabel, e.getClass().getSimpleName(), e.getMessage());
+            return fallback.get();
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // OpenRouter HTTP call
+    // ──────────────────────────────────────────────────────────────
+
+    private String callOpenRouter(PromptPair prompt) {
+        String url = openRouterConfig.getBaseUrl() + "/chat/completions";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(Objects.requireNonNull(openRouterConfig.getApiKey()));
+        headers.set("HTTP-Referer", openRouterConfig.getSiteUrl());
+        headers.set("X-Title", openRouterConfig.getSiteName());
+
+        Map<String, Object> requestBody = buildRequestBody(prompt);
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        ResponseEntity<String> response = selectionRestTemplate.exchange(
+                url, HttpMethod.POST, entity, String.class);
+
+        if (response.getStatusCode() != HttpStatus.OK) {
+            throw new RuntimeException("OpenRouter returned status: " + response.getStatusCode());
+        }
+
+        return extractContentFromResponse(response.getBody());
+    }
+
+    private Map<String, Object> buildRequestBody(PromptPair prompt) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("model", selectionProperties.getModel());
+
+        List<Map<String, Object>> messages = new ArrayList<>();
+        messages.add(Map.of("role", "system", "content", prompt.systemPrompt()));
+        messages.add(Map.of("role", "user", "content", prompt.userPrompt()));
+        body.put("messages", messages);
+
+        body.put("temperature", selectionProperties.getTemperature());
+        body.put("max_tokens", selectionProperties.getMaxTokens());
+        body.put("stream", false);
+
+        // Structured JSON output via schema
+        Map<String, Object> schema = promptBuilder.getSelectionResponseSchema();
+        body.put("response_format", Map.of(
+                "type", "json_schema",
+                "json_schema", Map.of(
+                        "name", "speaking_selection_response",
+                        "strict", true,
+                        "schema", schema)));
+
+        // Provider preferences
+        body.put("provider", Map.of(
+                "allow_fallbacks", true,
+                "data_collection", "allow"));
+
+        return body;
+    }
+
+    private String extractContentFromResponse(String responseBody) {
+        try {
+            JsonNode root = new com.fasterxml.jackson.databind.ObjectMapper().readTree(responseBody);
+            JsonNode choices = root.get("choices");
+            if (choices == null || !choices.isArray() || choices.isEmpty()) {
+                throw new RuntimeException("No choices in OpenRouter response");
+            }
+            JsonNode message = choices.get(0).get("message");
+            if (message == null || !message.hasNonNull("content")) {
+                throw new RuntimeException("No message content in OpenRouter response");
+            }
+            return message.get("content").asText();
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse OpenRouter response: " + e.getMessage(), e);
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────
+
+    private List<PlannerCandidate> resolveSelectedCandidates(
+            List<PlannerCandidate> bank, List<Long> selectedIds) {
+        Map<Long, PlannerCandidate> lookup = bank.stream()
+                .collect(Collectors.toMap(PlannerCandidate::sourceQuestionId, c -> c, (a, b) -> a));
+        List<PlannerCandidate> resolved = new ArrayList<>();
+        for (Long id : selectedIds) {
+            PlannerCandidate candidate = lookup.get(id);
+            if (candidate != null) {
+                resolved.add(candidate);
+            }
+        }
+        return resolved;
+    }
+
+    private int pickTargetTurnCount(SpeakingSessionProperties.PartPlan config) {
+        int min = config.getMinSelected();
+        int max = config.getMaxSelected();
+        if (min <= 0 || max <= 0 || max < min) {
+            throw new IllegalStateException("Invalid Speaking selection window configuration.");
+        }
+        if (min == max) {
+            return min;
+        }
+        return random.nextInt(max - min + 1) + min;
+    }
+
+    /**
+     * Functional interface for heuristic fallback suppliers.
+     */
+    @FunctionalInterface
+    private interface FallbackSupplier {
+        SelectionResult get();
+    }
+}

--- a/backend/src/main/java/com/cramer/service/implement/LlmSpeakingSelectionPlannerService.java
+++ b/backend/src/main/java/com/cramer/service/implement/LlmSpeakingSelectionPlannerService.java
@@ -8,6 +8,7 @@ import com.cramer.service.speaking.SpeakingSelectionPromptBuilder;
 import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.PromptPair;
 import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.SelectionParseResult;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -42,6 +43,7 @@ public class LlmSpeakingSelectionPlannerService implements SpeakingSelectionPlan
 
     private static final Logger log = LoggerFactory.getLogger(LlmSpeakingSelectionPlannerService.class);
     private static final String STRATEGY_LLM = "llm_selection_v1";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     private final OpenRouterConfig openRouterConfig;
     private final SpeakingSelectionProperties selectionProperties;
@@ -230,7 +232,7 @@ public class LlmSpeakingSelectionPlannerService implements SpeakingSelectionPlan
 
     private String extractContentFromResponse(String responseBody) {
         try {
-            JsonNode root = new com.fasterxml.jackson.databind.ObjectMapper().readTree(responseBody);
+            JsonNode root = OBJECT_MAPPER.readTree(responseBody);
             JsonNode choices = root.get("choices");
             if (choices == null || !choices.isArray() || choices.isEmpty()) {
                 throw new RuntimeException("No choices in OpenRouter response");

--- a/backend/src/main/java/com/cramer/service/speaking/SpeakingSelectionPromptBuilder.java
+++ b/backend/src/main/java/com/cramer/service/speaking/SpeakingSelectionPromptBuilder.java
@@ -1,0 +1,284 @@
+package com.cramer.service.speaking;
+
+import com.cramer.service.SpeakingSelectionPlannerService.PlannerCandidate;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+/**
+ * Builds prompts for LLM-based Speaking question selection and validates
+ * the LLM response against hard rules.
+ *
+ * <p>The LLM is instructed to select a subset of question IDs from an
+ * authored bank. It is <strong>never</strong> allowed to generate new
+ * questions. All output is validated before use; invalid responses trigger
+ * a fallback to the heuristic planner.</p>
+ *
+ * @since 2026-04-05
+ */
+@Component
+public class SpeakingSelectionPromptBuilder {
+
+    private static final Logger log = LoggerFactory.getLogger(SpeakingSelectionPromptBuilder.class);
+
+    private static final int PROMPT_TEXT_MAX_CHARS = 120;
+    private static final int PART2_CONTEXT_MAX_CHARS = 500;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // ────────────────────────────────────────────────────────────
+    // Prompt building
+    // ────────────────────────────────────────────────────────────
+
+    /**
+     * Build system + user prompts for Part 1 selection.
+     */
+    public PromptPair buildPart1Prompt(List<PlannerCandidate> bank, int targetTurnCount) {
+        String system = buildSelectionSystemPrompt("IELTS Speaking Part 1", targetTurnCount);
+        String user = buildBankUserPrompt(bank, targetTurnCount,
+                "Select questions for Part 1. "
+                + "Aim for 2-3 topic clusters to give coherence while keeping diversity.");
+        return new PromptPair(system, user);
+    }
+
+    /**
+     * Build system + user prompts for independent Part 3 selection.
+     */
+    public PromptPair buildIndependentPart3Prompt(List<PlannerCandidate> bank, int targetTurnCount) {
+        String system = buildSelectionSystemPrompt("IELTS Speaking Part 3", targetTurnCount);
+        String user = buildBankUserPrompt(bank, targetTurnCount,
+                "Select questions for Part 3 (standalone). "
+                + "Choose questions that form a coherent discussion cluster around related topics.");
+        return new PromptPair(system, user);
+    }
+
+    /**
+     * Build system + user prompts for Part 3 follow-up selection after Part 2.
+     */
+    public PromptPair buildFollowUpPart3Prompt(
+            List<PlannerCandidate> bank,
+            int targetTurnCount,
+            JsonNode part2QuestionSnapshot,
+            String part2TranscriptText) {
+        String system = buildSelectionSystemPrompt("IELTS Speaking Part 3 (follow-up)", targetTurnCount);
+
+        StringBuilder user = new StringBuilder();
+        user.append("## Part 2 Context\n\n");
+        user.append("The candidate answered a Part 2 cue card about:\n");
+        user.append("Topic: ").append(textValue(part2QuestionSnapshot, "topicLabel")).append("\n");
+        user.append("Prompt: ").append(truncate(textValue(part2QuestionSnapshot, "promptText"), PART2_CONTEXT_MAX_CHARS)).append("\n");
+
+        if (part2TranscriptText != null && !part2TranscriptText.isBlank()) {
+            user.append("\nCandidate's response (excerpt):\n");
+            user.append(truncate(part2TranscriptText.trim(), PART2_CONTEXT_MAX_CHARS)).append("\n");
+        }
+
+        user.append("\n## Task\n\n");
+        user.append("Select exactly ").append(targetTurnCount)
+            .append(" follow-up questions that naturally extend the Part 2 discussion. ")
+            .append("Questions should probe deeper into the themes from the cue card and the candidate's response.\n\n");
+
+        user.append("## Available Questions\n\n");
+        appendBankTable(user, bank);
+
+        return new PromptPair(system, user.toString());
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // JSON Schema for structured output
+    // ────────────────────────────────────────────────────────────
+
+    /**
+     * Returns the JSON Schema for the LLM selection response, suitable for
+     * OpenRouter's {@code response_format.json_schema.schema} field.
+     */
+    public Map<String, Object> getSelectionResponseSchema() {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+
+        Map<String, Object> properties = new LinkedHashMap<>();
+
+        Map<String, Object> idsProperty = new LinkedHashMap<>();
+        idsProperty.put("type", "array");
+        idsProperty.put("items", Map.of("type", "integer"));
+        idsProperty.put("description", "Selected question IDs from the provided bank. Must be exactly targetTurnCount items, no duplicates.");
+        properties.put("selectedQuestionIds", idsProperty);
+
+        Map<String, Object> reasoningProperty = new LinkedHashMap<>();
+        reasoningProperty.put("type", "string");
+        reasoningProperty.put("description", "Brief explanation of why these questions were selected (1-2 sentences).");
+        properties.put("reasoningSummary", reasoningProperty);
+
+        schema.put("properties", properties);
+        schema.put("required", List.of("selectedQuestionIds", "reasoningSummary"));
+        schema.put("additionalProperties", false);
+
+        return schema;
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Response parsing and validation
+    // ────────────────────────────────────────────────────────────
+
+    /**
+     * Parses the raw LLM response content and validates it against hard rules.
+     *
+     * @param llmContent       raw JSON string from the LLM
+     * @param bank             the candidate bank that was sent to the LLM
+     * @param targetTurnCount  the expected number of selected IDs
+     * @return a {@link SelectionParseResult} indicating validity and parsed data
+     */
+    public SelectionParseResult parseAndValidate(
+            String llmContent, List<PlannerCandidate> bank, int targetTurnCount) {
+
+        if (llmContent == null || llmContent.isBlank()) {
+            return SelectionParseResult.invalid("LLM returned empty content");
+        }
+
+        // Parse JSON
+        JsonNode root;
+        try {
+            root = objectMapper.readTree(llmContent);
+        } catch (Exception e) {
+            return SelectionParseResult.invalid("Failed to parse LLM JSON: " + e.getMessage());
+        }
+
+        // Extract selectedQuestionIds
+        JsonNode idsNode = root.get("selectedQuestionIds");
+        if (idsNode == null || !idsNode.isArray()) {
+            return SelectionParseResult.invalid("Missing or non-array 'selectedQuestionIds' field");
+        }
+
+        List<Long> selectedIds = new ArrayList<>();
+        LinkedHashSet<Long> deduped = new LinkedHashSet<>();
+        for (JsonNode idNode : idsNode) {
+            if (!idNode.isNumber()) {
+                return SelectionParseResult.invalid("Non-numeric value in selectedQuestionIds: " + idNode);
+            }
+            long id = idNode.longValue();
+            selectedIds.add(id);
+            deduped.add(id);
+        }
+
+        // Validation 1: correct count
+        if (selectedIds.size() != targetTurnCount) {
+            return SelectionParseResult.invalid(
+                    "Expected " + targetTurnCount + " IDs but got " + selectedIds.size());
+        }
+
+        // Validation 2: no duplicates
+        if (deduped.size() != selectedIds.size()) {
+            return SelectionParseResult.invalid(
+                    "Duplicate IDs found in selectedQuestionIds");
+        }
+
+        // Validation 3: all IDs exist in the bank
+        Set<Long> validIds = bank.stream()
+                .map(PlannerCandidate::sourceQuestionId)
+                .collect(Collectors.toSet());
+        for (Long id : selectedIds) {
+            if (!validIds.contains(id)) {
+                return SelectionParseResult.invalid(
+                        "Unknown question ID " + id + " not in the provided bank");
+            }
+        }
+
+        // Extract reasoning summary (optional, non-critical)
+        String reasoning = "";
+        JsonNode reasoningNode = root.get("reasoningSummary");
+        if (reasoningNode != null && reasoningNode.isTextual()) {
+            reasoning = reasoningNode.asText("");
+        }
+
+        return new SelectionParseResult(true, selectedIds, reasoning, null);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Private helpers
+    // ────────────────────────────────────────────────────────────
+
+    private String buildSelectionSystemPrompt(String partDescription, int targetTurnCount) {
+        return "You are an IELTS Speaking test question selector.\n\n"
+                + "## Rules\n"
+                + "1. Select exactly " + targetTurnCount + " questions from the provided bank.\n"
+                + "2. Return ONLY IDs that exist in the bank. Do NOT invent new IDs.\n"
+                + "3. No duplicate IDs.\n"
+                + "4. Do NOT generate or modify questions. You can ONLY select from what is given.\n"
+                + "5. Aim for topic coherence while maintaining diversity.\n"
+                + "6. For " + partDescription + ", prefer covering 2-3 related topic clusters rather than "
+                + "being too scattered or too repetitive.\n\n"
+                + "## Output Format\n"
+                + "Return a JSON object with:\n"
+                + "- \"selectedQuestionIds\": array of exactly " + targetTurnCount + " integer IDs\n"
+                + "- \"reasoningSummary\": a brief 1-2 sentence explanation of your selection rationale";
+    }
+
+    private String buildBankUserPrompt(List<PlannerCandidate> bank, int targetTurnCount, String instruction) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("## Task\n\n");
+        sb.append(instruction).append("\n");
+        sb.append("Select exactly ").append(targetTurnCount).append(" questions.\n\n");
+        sb.append("## Available Questions\n\n");
+        appendBankTable(sb, bank);
+        return sb.toString();
+    }
+
+    private void appendBankTable(StringBuilder sb, List<PlannerCandidate> bank) {
+        sb.append("| ID | Topic | Prompt |\n");
+        sb.append("|---|---|---|\n");
+        for (PlannerCandidate candidate : bank) {
+            sb.append("| ").append(candidate.sourceQuestionId());
+            sb.append(" | ").append(textValue(candidate.questionSnapshot(), "topicLabel"));
+            sb.append(" | ").append(truncate(textValue(candidate.questionSnapshot(), "promptText"), PROMPT_TEXT_MAX_CHARS));
+            sb.append(" |\n");
+        }
+    }
+
+    private String textValue(JsonNode node, String fieldName) {
+        if (node == null || !node.hasNonNull(fieldName)) {
+            return "(none)";
+        }
+        String value = node.get(fieldName).asText(null);
+        return (value == null || value.isBlank()) ? "(none)" : value;
+    }
+
+    private String truncate(String value, int maxLength) {
+        if (value == null || value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength - 3) + "...";
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Inner records
+    // ────────────────────────────────────────────────────────────
+
+    /**
+     * A pair of system prompt and user prompt.
+     */
+    public record PromptPair(String systemPrompt, String userPrompt) {
+    }
+
+    /**
+     * Result of parsing and validating the LLM selection response.
+     */
+    public record SelectionParseResult(
+            boolean valid,
+            List<Long> selectedIds,
+            String reasoningSummary,
+            String error) {
+
+        public static SelectionParseResult invalid(String error) {
+            return new SelectionParseResult(false, List.of(), "", error);
+        }
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -176,6 +176,14 @@ speaking.session.part3.min-selected=${SPEAKING_PART3_MIN_SELECTED:3}
 speaking.session.part3.max-selected=${SPEAKING_PART3_MAX_SELECTED:6}
 speaking.session.part3.defer-until-context=${SPEAKING_PART3_DEFER_UNTIL_CONTEXT:true}
 
+# Speaking question selection strategy (heuristic or llm)
+speaking.selection.provider=${SPEAKING_SELECTION_PROVIDER:heuristic}
+speaking.selection.model=${SPEAKING_SELECTION_MODEL:}
+speaking.selection.timeout-ms=${SPEAKING_SELECTION_TIMEOUT_MS:12000}
+speaking.selection.fallback=${SPEAKING_SELECTION_FALLBACK:heuristic}
+speaking.selection.temperature=${SPEAKING_SELECTION_TEMPERATURE:0.7}
+speaking.selection.max-tokens=${SPEAKING_SELECTION_MAX_TOKENS:512}
+
 # Gemini model for live conversation (gemini-2.0-flash-live recommended)
 # Gemini API Key (alternative to service account credentials)
 gemini.api.key=${GEMINI_API_KEY:}

--- a/backend/src/test/java/com/cramer/service/unit/LlmSpeakingSelectionPlannerServiceTest.java
+++ b/backend/src/test/java/com/cramer/service/unit/LlmSpeakingSelectionPlannerServiceTest.java
@@ -1,0 +1,359 @@
+package com.cramer.service.unit;
+
+import com.cramer.config.OpenRouterConfig;
+import com.cramer.config.SpeakingSelectionProperties;
+import com.cramer.config.SpeakingSessionProperties;
+import com.cramer.service.SpeakingSelectionPlannerService.PlannerCandidate;
+import com.cramer.service.SpeakingSelectionPlannerService.SelectionResult;
+import com.cramer.service.implement.HeuristicSpeakingSelectionPlannerService;
+import com.cramer.service.implement.LlmSpeakingSelectionPlannerService;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.PromptPair;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link LlmSpeakingSelectionPlannerService}.
+ *
+ * <p>Uses mocks for the OpenRouter HTTP layer and the prompt builder.
+ * Verifies LLM success path, validation failures, and heuristic fallback.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("LlmSpeakingSelectionPlannerService Unit Tests")
+class LlmSpeakingSelectionPlannerServiceTest {
+
+    @Mock
+    private SpeakingSelectionPromptBuilder promptBuilder;
+
+    @Mock
+    private RestTemplate mockRestTemplate;
+
+    private OpenRouterConfig openRouterConfig;
+    private SpeakingSelectionProperties selectionProperties;
+    private HeuristicSpeakingSelectionPlannerService heuristicFallback;
+    private LlmSpeakingSelectionPlannerService llmPlanner;
+    private ObjectMapper objectMapper;
+
+    private SpeakingSessionProperties.PartPlan part1Config;
+    private SpeakingSessionProperties.PartPlan part2Config;
+    private SpeakingSessionProperties.PartPlan part3Config;
+
+    @BeforeEach
+    void setUp() {
+        objectMapper = new ObjectMapper();
+
+        openRouterConfig = new OpenRouterConfig();
+        openRouterConfig.setApiKey("test-api-key");
+        openRouterConfig.setBaseUrl("https://openrouter.ai/api/v1");
+        openRouterConfig.setSiteUrl("https://cramer.vn");
+        openRouterConfig.setSiteName("Cramer Test");
+
+        selectionProperties = new SpeakingSelectionProperties();
+        selectionProperties.setProvider("llm");
+        selectionProperties.setModel("deepseek/deepseek-chat");
+        selectionProperties.setTimeoutMs(12000);
+        selectionProperties.setTemperature(0.7);
+        selectionProperties.setMaxTokens(512);
+
+        heuristicFallback = new HeuristicSpeakingSelectionPlannerService();
+
+        llmPlanner = new LlmSpeakingSelectionPlannerService(
+                openRouterConfig, selectionProperties, promptBuilder,
+                heuristicFallback, mockRestTemplate);
+
+        part1Config = new SpeakingSessionProperties.PartPlan(30, 8, 12, false);
+        part2Config = new SpeakingSessionProperties.PartPlan(1, 1, 1, false);
+        part3Config = new SpeakingSessionProperties.PartPlan(15, 3, 6, true);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // True LLM success path
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("selectPart1: LLM returns valid JSON -> strategy = llm_selection_v1, IDs from bank")
+    void selectPart1_validLlmResponse_returnsLlmSelectionV1Strategy() {
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study", "Hobbies");
+
+        PromptPair fakePrompt = new PromptPair("system prompt", "user prompt");
+        when(promptBuilder.buildPart1Prompt(eq(bank), anyInt())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        // Simulate valid LLM response with 10 IDs from the bank (covers any targetTurnCount in [8,12])
+        // We use parseAndValidate mock to return valid result with exactly the requested count
+        when(promptBuilder.parseAndValidate(anyString(), eq(bank), anyInt())).thenAnswer(invocation -> {
+            int requestedCount = invocation.getArgument(2);
+            List<Long> ids = new ArrayList<>();
+            for (int i = 0; i < requestedCount; i++) {
+                ids.add(1000L + i);
+            }
+            return new SpeakingSelectionPromptBuilder.SelectionParseResult(
+                    true, ids, "Selected diverse topic clusters.", null);
+        });
+
+        // Mock HTTP call to return a valid OpenRouter response
+        String fakeResponseBody = """
+                {
+                  "choices": [{
+                    "message": {
+                      "content": "{\\"selectedQuestionIds\\":[1000,1001,1002],\\"reasoningSummary\\":\\"test\\"}"
+                    }
+                  }]
+                }
+                """;
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(fakeResponseBody, HttpStatus.OK));
+
+        SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.strategy()).isEqualTo("llm_selection_v1");
+        assertThat(result.targetTurnCount()).isBetween(8, 12);
+        assertThat(result.selectedCandidates()).hasSize(result.targetTurnCount());
+
+        // All selected IDs must be from the bank
+        Set<Long> bankIds = bank.stream()
+                .map(PlannerCandidate::sourceQuestionId)
+                .collect(Collectors.toSet());
+        for (PlannerCandidate selected : result.selectedCandidates()) {
+            assertThat(bankIds).contains(selected.sourceQuestionId());
+        }
+    }
+
+    @Test
+    @DisplayName("selectPart1: LLM returns invalid selection -> falls back to heuristic")
+    void selectPart1_invalidLlmResponse_fallsBackToHeuristic() {
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study", "Hobbies");
+
+        PromptPair fakePrompt = new PromptPair("system", "user");
+        when(promptBuilder.buildPart1Prompt(eq(bank), anyInt())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        // HTTP returns OK but parseAndValidate returns invalid
+        String fakeResponseBody = """
+                {
+                  "choices": [{
+                    "message": { "content": "{\\"selectedQuestionIds\\":[9999],\\"reasoningSummary\\":\\"bad\\"}" }
+                  }]
+                }
+                """;
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenReturn(new ResponseEntity<>(fakeResponseBody, HttpStatus.OK));
+        when(promptBuilder.parseAndValidate(anyString(), eq(bank), anyInt()))
+                .thenReturn(SpeakingSelectionPromptBuilder.SelectionParseResult.invalid("wrong count"));
+
+        SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.strategy()).isEqualTo("topic_cluster_random_v1");
+        assertThat(result.targetTurnCount()).isBetween(8, 12);
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Fallback paths
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("selectPart1: LLM HTTP exception -> falls back to heuristic")
+    void selectPart1_llmException_fallsBackToHeuristic() {
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study", "Hobbies");
+
+        PromptPair fakePrompt = new PromptPair("system", "user");
+        when(promptBuilder.buildPart1Prompt(eq(bank), anyInt())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        // HTTP call throws exception
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Connection refused"));
+
+        SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.targetTurnCount()).isBetween(8, 12);
+        assertThat(result.selectedCandidates()).hasSizeBetween(8, 12);
+        assertThat(result.strategy()).isEqualTo("topic_cluster_random_v1");
+    }
+
+    @Test
+    @DisplayName("selectPart2: Always delegates to heuristic regardless of provider")
+    void selectPart2_alwaysUsesHeuristic() {
+        List<PlannerCandidate> bank = buildBank(1, "PART_2", "City life");
+
+        SelectionResult result = llmPlanner.selectPart2(bank, part2Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.targetTurnCount()).isEqualTo(1);
+        assertThat(result.selectedCandidates()).hasSize(1);
+        assertThat(result.strategy()).isEqualTo("single_cue_card_v1");
+    }
+
+    @Test
+    @DisplayName("selectIndependentPart3: LLM fails -> falls back to heuristic with 3..6 selections")
+    void selectIndependentPart3_llmFails_fallsBackToHeuristic() {
+        List<PlannerCandidate> bank = buildBank(15, "PART_3", "Education", "Technology");
+
+        PromptPair fakePrompt = new PromptPair("system", "user");
+        when(promptBuilder.buildIndependentPart3Prompt(eq(bank), anyInt())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Timeout"));
+
+        SelectionResult result = llmPlanner.selectIndependentPart3(bank, part3Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.targetTurnCount()).isBetween(3, 6);
+        assertThat(result.selectedCandidates()).hasSizeBetween(3, 6);
+        assertThat(result.strategy()).isEqualTo("topic_cluster_random_v1");
+    }
+
+    @Test
+    @DisplayName("selectFollowUpPart3: LLM fails -> falls back to heuristic")
+    void selectFollowUpPart3_llmFails_fallsBackToHeuristic() {
+        List<PlannerCandidate> bank = buildBank(15, "PART_3", "Travel");
+        ObjectNode part2Snapshot = buildSnapshot("PART_2", "Travel", "Describe a city you visited");
+
+        PromptPair fakePrompt = new PromptPair("system", "user");
+        when(promptBuilder.buildFollowUpPart3Prompt(eq(bank), anyInt(), any(), any())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Timeout"));
+
+        SelectionResult result = llmPlanner.selectFollowUpPart3(
+                bank, part2Snapshot, "I visited London last year.", part3Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.targetTurnCount()).isBetween(3, 6);
+        assertThat(result.selectedCandidates()).hasSizeBetween(3, 6);
+        assertThat(result.strategy()).isEqualTo("follow_up_context_v1");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Guard conditions
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("selectPart1: No model configured -> immediate heuristic fallback")
+    void selectPart1_noModel_fallsBackImmediately() {
+        selectionProperties.setModel("");
+        llmPlanner = new LlmSpeakingSelectionPlannerService(
+                openRouterConfig, selectionProperties, promptBuilder,
+                heuristicFallback, mockRestTemplate);
+
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study");
+
+        SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.strategy()).isEqualTo("topic_cluster_random_v1");
+        verify(promptBuilder, never()).buildPart1Prompt(anyList(), anyInt());
+    }
+
+    @Test
+    @DisplayName("selectPart1: No API key configured -> immediate heuristic fallback")
+    void selectPart1_noApiKey_fallsBackImmediately() {
+        openRouterConfig.setApiKey("");
+        llmPlanner = new LlmSpeakingSelectionPlannerService(
+                openRouterConfig, selectionProperties, promptBuilder,
+                heuristicFallback, mockRestTemplate);
+
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study");
+
+        SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+
+        assertThat(result).isNotNull();
+        assertThat(result.strategy()).isEqualTo("topic_cluster_random_v1");
+        verify(promptBuilder, never()).buildPart1Prompt(anyList(), anyInt());
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Fallback re-randomization
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("Heuristic fallback re-randomizes its own targetTurnCount")
+    void fallback_reRandomizesTargetTurnCount() {
+        List<PlannerCandidate> bank = buildBank(30, "PART_1", "Work", "Study", "Hobbies");
+
+        PromptPair fakePrompt = new PromptPair("system", "user");
+        when(promptBuilder.buildPart1Prompt(eq(bank), anyInt())).thenReturn(fakePrompt);
+        when(promptBuilder.getSelectionResponseSchema()).thenReturn(java.util.Map.of());
+
+        when(mockRestTemplate.exchange(
+                anyString(), eq(HttpMethod.POST), any(HttpEntity.class), eq(String.class)))
+                .thenThrow(new ResourceAccessException("Timeout"));
+
+        // Run multiple times to show heuristic owns its own targetTurnCount
+        boolean sawDifferentCounts = false;
+        int firstCount = -1;
+        for (int i = 0; i < 20; i++) {
+            SelectionResult result = llmPlanner.selectPart1(bank, part1Config);
+            assertThat(result.targetTurnCount()).isBetween(8, 12);
+            assertThat(result.selectedCandidates()).hasSize(result.targetTurnCount());
+            if (firstCount == -1) {
+                firstCount = result.targetTurnCount();
+            } else if (result.targetTurnCount() != firstCount) {
+                sawDifferentCounts = true;
+            }
+        }
+        // With 20 runs across [8,12], it's statistically near-certain we see variation
+        assertThat(sawDifferentCounts)
+                .as("Heuristic should re-randomize targetTurnCount independently")
+                .isTrue();
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────
+
+    private List<PlannerCandidate> buildBank(int count, String partType, String... topics) {
+        List<PlannerCandidate> bank = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            String topic = topics[i % topics.length];
+            ObjectNode snapshot = buildSnapshot(partType, topic, partType + " prompt " + (i + 1) + " about " + topic);
+            bank.add(new PlannerCandidate(1000L + i, i + 1, snapshot));
+        }
+        return bank;
+    }
+
+    private ObjectNode buildSnapshot(String partType, String topicLabel, String promptText) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("schemaVersion", 1);
+        node.put("partType", partType);
+        node.put("promptText", promptText);
+        node.put("topicLabel", topicLabel);
+        return node;
+    }
+}

--- a/backend/src/test/java/com/cramer/service/unit/SpeakingSelectionPromptBuilderTest.java
+++ b/backend/src/test/java/com/cramer/service/unit/SpeakingSelectionPromptBuilderTest.java
@@ -1,0 +1,268 @@
+package com.cramer.service.unit;
+
+import com.cramer.service.SpeakingSelectionPlannerService.PlannerCandidate;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.PromptPair;
+import com.cramer.service.speaking.SpeakingSelectionPromptBuilder.SelectionParseResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link SpeakingSelectionPromptBuilder}.
+ *
+ * <p>Tests prompt construction, JSON schema generation, and response
+ * parsing/validation logic. No Spring context or mocks needed -- pure
+ * unit tests.</p>
+ */
+@DisplayName("SpeakingSelectionPromptBuilder Unit Tests")
+class SpeakingSelectionPromptBuilderTest {
+
+    private SpeakingSelectionPromptBuilder promptBuilder;
+    private ObjectMapper objectMapper;
+
+    @BeforeEach
+    void setUp() {
+        promptBuilder = new SpeakingSelectionPromptBuilder();
+        objectMapper = new ObjectMapper();
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // parseAndValidate: success
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("parseAndValidate with valid response returns valid=true and correct IDs")
+    void parseAndValidate_validResponse_returnsValid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = """
+                {
+                  "selectedQuestionIds": [1000, 1001, 1002, 1003, 1004],
+                  "reasoningSummary": "Balanced selection across topics."
+                }
+                """;
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isTrue();
+        assertThat(result.selectedIds()).containsExactly(1000L, 1001L, 1002L, 1003L, 1004L);
+        assertThat(result.reasoningSummary()).isEqualTo("Balanced selection across topics.");
+        assertThat(result.error()).isNull();
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // parseAndValidate: validation failures
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("parseAndValidate with wrong count returns valid=false")
+    void parseAndValidate_wrongCount_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = """
+                {
+                  "selectedQuestionIds": [1000, 1001, 1002],
+                  "reasoningSummary": "Short selection."
+                }
+                """;
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("Expected 5 IDs but got 3");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with unknown IDs returns valid=false")
+    void parseAndValidate_unknownIds_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = """
+                {
+                  "selectedQuestionIds": [1000, 1001, 9999, 1003, 1004],
+                  "reasoningSummary": "Has unknown ID."
+                }
+                """;
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("Unknown question ID 9999");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with duplicate IDs returns valid=false")
+    void parseAndValidate_duplicateIds_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = """
+                {
+                  "selectedQuestionIds": [1000, 1001, 1001, 1003, 1004],
+                  "reasoningSummary": "Has duplicate."
+                }
+                """;
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("Duplicate IDs");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with malformed JSON returns valid=false")
+    void parseAndValidate_malformedJson_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = "this is not valid json {{{";
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("Failed to parse LLM JSON");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with empty content returns valid=false")
+    void parseAndValidate_emptyContent_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+
+        SelectionParseResult result = promptBuilder.parseAndValidate("", bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("empty content");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with null content returns valid=false")
+    void parseAndValidate_nullContent_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(null, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("empty content");
+    }
+
+    @Test
+    @DisplayName("parseAndValidate with missing selectedQuestionIds field returns valid=false")
+    void parseAndValidate_missingField_returnsInvalid() {
+        List<PlannerCandidate> bank = buildBank(10);
+        String json = """
+                {
+                  "reasoningSummary": "No IDs field."
+                }
+                """;
+
+        SelectionParseResult result = promptBuilder.parseAndValidate(json, bank, 5);
+
+        assertThat(result.valid()).isFalse();
+        assertThat(result.error()).contains("Missing or non-array");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Prompt building
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("buildPart1Prompt includes bank data in user prompt and rules in system prompt")
+    void buildPart1Prompt_containsBankData() {
+        List<PlannerCandidate> bank = buildBank(5);
+
+        PromptPair prompt = promptBuilder.buildPart1Prompt(bank, 3);
+
+        // System prompt should contain rules
+        assertThat(prompt.systemPrompt()).contains("Select exactly 3 questions");
+        assertThat(prompt.systemPrompt()).contains("Do NOT generate or modify questions");
+        assertThat(prompt.systemPrompt()).contains("No duplicate IDs");
+
+        // User prompt should list all candidates
+        assertThat(prompt.userPrompt()).contains("1000");
+        assertThat(prompt.userPrompt()).contains("1004");
+        assertThat(prompt.userPrompt()).contains("Work");
+        assertThat(prompt.userPrompt()).contains("Study");
+    }
+
+    @Test
+    @DisplayName("buildPart1Prompt handles null topicLabel candidate without NPE")
+    void buildPart1Prompt_nullTopicLabel_noCrash() {
+        List<PlannerCandidate> bank = new ArrayList<>();
+        ObjectNode snapshot = objectMapper.createObjectNode();
+        snapshot.put("schemaVersion", 1);
+        snapshot.put("partType", "PART_1");
+        snapshot.put("promptText", "Tell me about your hometown.");
+        // topicLabel intentionally omitted
+        bank.add(new PlannerCandidate(2000L, 1, snapshot));
+
+        PromptPair prompt = promptBuilder.buildPart1Prompt(bank, 1);
+
+        assertThat(prompt.userPrompt()).contains("2000");
+        assertThat(prompt.userPrompt()).contains("(none)");
+    }
+
+    @Test
+    @DisplayName("buildFollowUpPart3Prompt includes Part 2 context")
+    void buildFollowUpPart3Prompt_includesPart2Context() {
+        List<PlannerCandidate> bank = buildBank(5);
+        ObjectNode part2Snapshot = objectMapper.createObjectNode();
+        part2Snapshot.put("topicLabel", "Travel");
+        part2Snapshot.put("promptText", "Describe a memorable trip.");
+
+        PromptPair prompt = promptBuilder.buildFollowUpPart3Prompt(
+                bank, 3, part2Snapshot, "I visited London and enjoyed the museums.");
+
+        assertThat(prompt.userPrompt()).contains("Travel");
+        assertThat(prompt.userPrompt()).contains("Describe a memorable trip.");
+        assertThat(prompt.userPrompt()).contains("I visited London");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // JSON Schema
+    // ────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("getSelectionResponseSchema returns valid schema with required fields")
+    @SuppressWarnings("unchecked")
+    void getSelectionResponseSchema_hasRequiredFields() {
+        Map<String, Object> schema = promptBuilder.getSelectionResponseSchema();
+
+        assertThat(schema).containsKey("type");
+        assertThat(schema.get("type")).isEqualTo("object");
+        assertThat(schema).containsKey("properties");
+        assertThat(schema).containsKey("required");
+
+        Map<String, Object> properties = (Map<String, Object>) schema.get("properties");
+        assertThat(properties).containsKey("selectedQuestionIds");
+        assertThat(properties).containsKey("reasoningSummary");
+
+        List<String> required = (List<String>) schema.get("required");
+        assertThat(required).contains("selectedQuestionIds", "reasoningSummary");
+
+        Map<String, Object> idsSchema = (Map<String, Object>) properties.get("selectedQuestionIds");
+        assertThat(idsSchema.get("type")).isEqualTo("array");
+
+        Map<String, Object> reasoningSchema = (Map<String, Object>) properties.get("reasoningSummary");
+        assertThat(reasoningSchema.get("type")).isEqualTo("string");
+    }
+
+    // ────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────
+
+    private List<PlannerCandidate> buildBank(int count) {
+        List<PlannerCandidate> bank = new ArrayList<>();
+        String[] topics = {"Work", "Study", "Hobbies"};
+        for (int i = 0; i < count; i++) {
+            String topic = topics[i % topics.length];
+            ObjectNode snapshot = objectMapper.createObjectNode();
+            snapshot.put("schemaVersion", 1);
+            snapshot.put("partType", "PART_1");
+            snapshot.put("promptText", "Prompt " + (i + 1) + " about " + topic);
+            snapshot.put("topicLabel", topic);
+            bank.add(new PlannerCandidate(1000L + i, i + 1, snapshot));
+        }
+        return bank;
+    }
+}

--- a/docs/library/backend/SERVICES.md
+++ b/docs/library/backend/SERVICES.md
@@ -1,6 +1,6 @@
 # Cramer Backend - Service Layer Documentation
 
-> **Last Updated:** January 10, 2026  
+> **Last Updated:** April 5, 2026  
 > **Spring Boot Version:** 3.x  
 > **Architecture:** Interface + Implementation pattern
 
@@ -70,8 +70,10 @@ This document provides a comprehensive reference for all services in the Cramer 
 | 39 | `SpeakingContentService` | Interface | service | Build session blueprint from shared hierarchy authored content |
 | 40 | `SpeakingSelectionPlannerService` | Interface | service | Select Speaking question subsets for runtime turns |
 | 41 | `SpeakingEvaluationDispatchService` | Interface | service | Dispatch grading/evaluation after session completion |
+| 42 | `LlmSpeakingSelectionPlannerService` | Concrete | service.implement | LLM-powered Speaking question selection with heuristic fallback |
+| 43 | `SpeakingSelectionPromptBuilder` | Concrete | service.speaking | LLM prompt building and response parsing for Speaking selection |
 
-**Total Services: 41** (Interface: 19, Concrete: 22)
+**Total Services: 43** (Interface: 19, Concrete: 24)
 
 ### Speaking Runtime Services
 
@@ -80,13 +82,25 @@ This document provides a comprehensive reference for all services in the Cramer 
 | `SpeakingSessionService` | Interface | service | Speaking session lifecycle orchestration |
 | `SpeakingContentService` | Interface | service | Build session blueprint from shared hierarchy authored content |
 | `SpeakingSelectionPlannerService` | Interface | service | Select Speaking question subsets for runtime turns |
+| `HeuristicSpeakingSelectionPlannerService` | Concrete | service.implement | Heuristic (topic-cluster-random) question selection planner |
+| `LlmSpeakingSelectionPlannerService` | Concrete | service.implement | LLM-powered question selection with heuristic fallback |
+| `SpeakingSelectionPromptBuilder` | Concrete | service.speaking | Builds LLM prompts and parses/validates selection responses |
 | `SpeakingEvaluationDispatchService` | Interface | service | Dispatch grading/evaluation after session completion |
+
+**Configuration classes:**
+
+| Config | Package | Purpose |
+|---|---|---|
+| `SpeakingSelectionProperties` | config | `speaking.selection.*` props (provider, model, timeout, temperature, maxTokens) |
+| `SpeakingSelectionPlannerConfig` | config | Bean wiring — selects `LlmSpeakingSelectionPlannerService` or `HeuristicSpeakingSelectionPlannerService` based on `speaking.selection.provider` |
 
 **Implementation notes:**
 
 - Active runtime authored content is read from `tests -> sections -> questions`
 - Runtime truth is stored in `speaking_sessions` and `speaking_transcripts`
 - No active runtime service should depend on `speaking_*_legacy`
+- `LlmSpeakingSelectionPlannerService` uses its own `RestTemplate` (12s timeout) and injects `OpenRouterConfig` for credentials — it does **not** modify `OpenRouterClient`
+- When `speaking.selection.provider=heuristic` (default), `SpeakingSelectionPlannerConfig` registers `HeuristicSpeakingSelectionPlannerService` as the active bean; when `llm`, it wraps it with `LlmSpeakingSelectionPlannerService` which auto-falls back on any failure
 
 ---
 


### PR DESCRIPTION
## Summary

Implement configurable Speaking question selection planner that supports both heuristic (default) and LLM-based (via OpenRouter) strategies. The LLM planner builds structured prompts from the question bank, parses validated question ID selections, and falls back safely to heuristic on any failure (network, parse, timeout).

Closes: relates to #9

## What changed

### New files (6)
- `SpeakingSelectionProperties.java` — config props: provider, model, timeout, temperature, max-tokens, fallback
- `SpeakingSelectionPlannerConfig.java` — conditional bean wiring (`@ConditionalOnProperty(provider=llm)` + `@ConditionalOnMissingBean` for heuristic default)
- `SpeakingSelectionPromptBuilder.java` — builds LLM prompt from bank metadata + parses/validates JSON response
- `LlmSpeakingSelectionPlannerService.java` — LLM planner with guard checks (API key, model) and safe fallback to heuristic on all error paths
- `LlmSpeakingSelectionPlannerServiceTest.java` — 9 unit tests (success paths, fallback paths, guard paths)
- `SpeakingSelectionPromptBuilderTest.java` — 12 unit tests (prompt build, parse, validation)

### Modified files (3)
- `HeuristicSpeakingSelectionPlannerService.java` — removed `@Service` annotation (bean registration moved to Config)
- `application.properties` — 6 new `speaking.selection.*` config entries
- `docs/library/backend/SERVICES.md` — updated service count (43)

## Configuration

```properties
speaking.selection.provider=heuristic         
speaking.selection.model=                       
speaking.selection.timeout-ms=12000
speaking.selection.fallback=heuristic
speaking.selection.temperature=0.7
speaking.selection.max-tokens=512
```